### PR TITLE
fix(functions2): Change signature to trigger precise error message: (…

### DIFF
--- a/exercises/functions/functions2.rs
+++ b/exercises/functions/functions2.rs
@@ -7,7 +7,7 @@ fn main() {
     call_me(3);
 }
 
-fn call_me(num) {
+fn call_me(num:) {
     for i in 0..num {
         println!("Ring! Call number {}", i + 1);
     }


### PR DESCRIPTION
…#605)

Now trigger this error:
```
error: expected type, found `)`
  --> exercises/functions/functions2.rs:10:16
   |
10 | fn call_me(num:) {
   |                ^ expected type

```